### PR TITLE
Fixes package path name format for Windows.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,11 +30,11 @@ module.exports = function(grunt)
 			}
 		},
 		exec: {
-			package: "'<%= settings.packager %>' " +
+			package: "\"<%= settings.packager %>\" " +
 				"-sign " +
 				"src " +
-				"'<%= output %>' " +
-				"<%= settings.keystore %> " +
+				"\"<%= output %>\" " +
+				"\"<%= settings.keystore %>\" " +
 				"<%= settings.storepass %>"
 				
 		},


### PR DESCRIPTION
Windows doesn't seem to handle single quotes correctly. This replaces the single quotes with double quotes so that the packager call and resulting output filename work correctly.